### PR TITLE
FIX: Use top-level namespace for base classes

### DIFF
--- a/app/jobs/onceoff/migrate_static_pages_plugin.rb
+++ b/app/jobs/onceoff/migrate_static_pages_plugin.rb
@@ -1,5 +1,5 @@
 module Jobs
-  class MigrateStaticPagesPlugin < Jobs::Onceoff
+  class MigrateStaticPagesPlugin < ::Jobs::Onceoff
     # Migrate content from dl_static_pages name to procourse_static_pages
     def execute_onceoff(args)
         dl_page_presence = PluginStoreRow.where(plugin_name: "dl_static_pages").exists?


### PR DESCRIPTION
Fix similar to that one: https://github.com/discourse/discourse-assign/commit/d59e7fe1fbe95789324010b3729d0589a8a9789f

This is necessary since Discourse moved to Zeitwerk autoloader