### PR TITLE
FIX: Change deprecated helper.whiteList to helper.allowList

### DIFF
--- a/assets/javascripts/lib/discourse-markdown/whitelist-tags.js.es6
+++ b/assets/javascripts/lib/discourse-markdown/whitelist-tags.js.es6
@@ -1,5 +1,5 @@
 export function setup(helper) {
-  helper.whiteList([ 
+  helper.allowList([ 
                   'a.btn',
                   'a.btn btn-primary',
                   'a.btn btn-danger',


### PR DESCRIPTION
Solves error 500 (`MiniRacer::RuntimeError (TypeError: Cannot read properties of undefined (reading 'throwOnUnhandled')) lib/pretty_text.rb:231` in Discourse error log) when posting/replying by changing the deprecated helper.whiteList to helper.allowList.  