### PR TITLE
FIX: Fixes stuck Plugins page and the plugin options no longer loading

### DIFF
--- a/assets/javascripts/discourse/controllers/admin-plugins-procourse-static-pages.js.es6
+++ b/assets/javascripts/discourse/controllers/admin-plugins-procourse-static-pages.js.es6
@@ -1,15 +1,15 @@
 import Page from '../models/page';
 import Controller from '@ember/controller';
-import { observer, computed } from "@ember/object";
+import EmberObject, { observer, computed } from "@ember/object";
 
 export default Controller.extend({
 
   pageURL: document.location.origin + "/page/",
 
   basePCPage: computed('model.@each.id', function() {
-    const page = Em.Object.create({});
-    a.set('title', I18n.t('admin.procourse_static_pages.pages.new_title'));
-    a.set('active', false);
+    const page = EmberObject.create({});
+    page.set('title', I18n.t('admin.procourse_static_pages.pages.new_title'));
+    page.set('active', false);
     return page;
   }),
 
@@ -92,7 +92,7 @@ export default Controller.extend({
 
     newPCPage: function() {
       var basePCPage = this.get('basePCPage');
-      const newPCPage = Em.Object.create(basePCPage);
+      const newPCPage = EmberObject.create(basePCPage);
       var newTitle = I18n.t('admin.procourse_static_pages.pages.new_title');
       newPCPage.set('title', newTitle);
       newPCPage.set('slug', this.slugify(newTitle));

--- a/assets/javascripts/discourse/controllers/admin-plugins-procourse-static-pages.js.es6
+++ b/assets/javascripts/discourse/controllers/admin-plugins-procourse-static-pages.js.es6
@@ -1,30 +1,32 @@
 import Page from '../models/page';
+import Controller from '@ember/controller';
+import { observer, computed } from "@ember/object";
 
-export default Ember.Controller.extend({
+export default Controller.extend({
 
   pageURL: document.location.origin + "/page/",
 
-  basePCPage: function() {
-    const a = Em.Object.create({});
+  basePCPage: computed('model.@each.id', function() {
+    const page = Em.Object.create({});
     a.set('title', I18n.t('admin.procourse_static_pages.pages.new_title'));
     a.set('active', false);
-    return a;
-  }.property('model.@each.id'),
+    return page;
+  }),
 
   removeSelected: function() {
     this.get('model').removeObject(this.get('selectedItem'));
     this.set('selectedItem', null);
   },
 
-  editTitle: function(){
+  editTitle: observer('selectedItem.title', function() {
     this.set('editingTitle', true);
     if (this.get('selectedItem') && !this.get('selectedItem').custom_slug && this.get('selectedItem').selected){
       this.get('selectedItem').set('slug', this.slugify(this.get('selectedItem').title));
     };
     this.set('editingTitle', false);
-  }.observes('selectedItem.title'),
+  }),
 
-  editSlug: function(){
+  editSlug: observer('selectedItem.slug', function() {
     if (this.get('selectedItem') && !this.get('editingTitle') && this.get('selectedItem').selected){
       if (this.get('originals').slug == this.get('selectedItem').slug){
         this.get('selectedItem').set('custom_slug', this.get('originals').custom_slug);
@@ -33,9 +35,9 @@ export default Ember.Controller.extend({
         this.get('selectedItem').set('custom_slug', true);
       }
     }
-  }.observes('selectedItem.slug'),
+  }),
 
-  changed: function(){
+  changed: observer('selectedItem.title', 'selectedItem.slug', 'selectedItem.group', 'selectedItem.raw', 'selectedItem.html', 'selectedItem.html_content', function() {
     if (!this.get('originals') || !this.get('selectedItem')) {this.set('disableSave', true); return;}
     if (((this.get('originals').title == this.get('selectedItem').title) &&
       (this.get('originals').slug == this.get('selectedItem').slug) &&
@@ -54,7 +56,7 @@ export default Ember.Controller.extend({
     else{
       this.set('disableSave', false);
     };
-  }.observes('selectedItem.title', 'selectedItem.slug', 'selectedItem.group', 'selectedItem.raw', 'selectedItem.html', 'selectedItem.html_content'),
+  }),
 
   slugify: function(text){
     return text.toString().toLowerCase()
@@ -109,13 +111,13 @@ export default Ember.Controller.extend({
       Page.save(this.get('selectedItem'), true);
     },
 
-    disableEnable: function() {
+    disableEnable: computed('id', 'saving', function() {
       return !this.get('id') || this.get('saving');
-    }.property('id', 'saving'),
+    }),   
 
-    newRecord: function() {
-      return (!this.get('id'));
-    }.property('id'),
+    newRecord: computed('id', function() {
+      return !this.get('id');
+    }),    
 
     save: function() {
       if (this.get('selectedItem').slug == this.slugify(this.get('selectedItem').title)){

--- a/assets/javascripts/discourse/models/page.js.es6
+++ b/assets/javascripts/discourse/models/page.js.es6
@@ -3,6 +3,7 @@ import { default as PrettyText, buildOptions } from 'pretty-text/pretty-text';
 import Group from 'discourse/models/group';
 import EmberObject, { observer } from '@ember/object';
 import { Array as EmberArray } from '@ember/array';
+import { Handlebars } from 'discourse-common/lib/raw-handlebars';
 import { getURLWithCDN } from "discourse-common/lib/get-url";
 
 const StaticPage = EmberObject.extend({

--- a/assets/javascripts/discourse/models/page.js.es6
+++ b/assets/javascripts/discourse/models/page.js.es6
@@ -5,7 +5,12 @@ import EmberObject, { observer } from '@ember/object';
 import { Array as EmberArray } from '@ember/array';
 import { getURLWithCDN } from "discourse-common/lib/get-url";
 
-const StaticPage = EmberObject.extend();
+const StaticPage = EmberObject.extend({
+
+  init: function() {
+    this._super(...arguments);
+  }
+});
 
 function getOpts() {
   const siteSettings = Discourse.__container__.lookup('site-settings:main');
@@ -30,20 +35,20 @@ var StaticPages = EmberObject.extend({
 StaticPage.reopenClass({
 
   findAll: function() {
-    return ajax('/procourse-static-pages/admin/pages.json').then(function(pages) {
-      const staticPages = Array();
-      if (pages) {
+    var staticPages = StaticPages.create({ content: [], loading: true });
+    ajax('/procourse-static-pages/admin/pages.json').then(function(pages) {
+      if (pages){
         pages.forEach((staticPage) => {
           var page = JSON.parse(staticPage.value);
-          const cooked = page.html ? '' : new PrettyText(getOpts()).cook(page.raw).string;
           staticPages.pushObject(StaticPage.create({
             ...page,
-            cooked: cooked
+            cooked: page.html ? '' : new Handlebars.SafeString(new PrettyText(getOpts()).cook(page.raw)).string
           }));
         });
       }
-      return Array(staticPages);
+      staticPages.set('loading', false);
     });
+    return staticPages;
   },
 
   save: function(object, enabledOnly=false) {

--- a/assets/javascripts/discourse/models/page.js.es6
+++ b/assets/javascripts/discourse/models/page.js.es6
@@ -3,6 +3,7 @@ import { default as PrettyText, buildOptions } from 'pretty-text/pretty-text';
 import Group from 'discourse/models/group';
 import EmberObject, { observer } from '@ember/object';
 import { Array as EmberArray } from '@ember/array';
+import { Handlebars } from 'discourse-common/lib/raw-handlebars';
 import { getURLWithCDN } from "discourse-common/lib/get-url";
 
 const StaticPage = EmberObject.extend({
@@ -67,7 +68,7 @@ StaticPage.reopenClass({
         var cooked = "";
       }
       else {
-        var cooked = new PrettyText(getOpts()).cook(object.raw);
+        var cooked = new Handlebars.SafeString(new PrettyText(getOpts()).cook(object.raw));
       }
       data = {
         ...data,

--- a/assets/javascripts/discourse/models/page.js.es6
+++ b/assets/javascripts/discourse/models/page.js.es6
@@ -36,7 +36,7 @@ var StaticPages = EmberObject.extend({
 StaticPage.reopenClass({
 
   findAll: function() {
-    var staticPages = StaticPages.create({ content: [], loading: true });
+    var staticPages = Array(StaticPages.create({ content: [], loading: true }));
     ajax('/procourse-static-pages/admin/pages.json').then(function(pages) {
       if (pages){
         pages.forEach((staticPage) => {

--- a/assets/javascripts/discourse/models/page.js.es6
+++ b/assets/javascripts/discourse/models/page.js.es6
@@ -42,8 +42,7 @@ StaticPage.reopenClass({
         pages.forEach((staticPage) => {
           var page = JSON.parse(staticPage.value);
           staticPages.pushObject(StaticPage.create({
-            ...page,
-            cooked: page.html ? '' : new Handlebars.SafeString(new PrettyText(getOpts()).cook(page.raw)).string
+            ...page
           }));
         });
       }

--- a/assets/javascripts/discourse/models/page.js.es6
+++ b/assets/javascripts/discourse/models/page.js.es6
@@ -3,7 +3,6 @@ import { default as PrettyText, buildOptions } from 'pretty-text/pretty-text';
 import Group from 'discourse/models/group';
 import EmberObject, { observer } from '@ember/object';
 import { Array as EmberArray } from '@ember/array';
-import { Handlebars } from 'discourse-common/lib/raw-handlebars';
 import { getURLWithCDN } from "discourse-common/lib/get-url";
 
 const StaticPage = EmberObject.extend({
@@ -68,7 +67,7 @@ StaticPage.reopenClass({
         var cooked = "";
       }
       else {
-        var cooked = new Handlebars.SafeString(new PrettyText(getOpts()).cook(object.raw));
+        var cooked = new PrettyText(getOpts()).cook(object.raw);
       }
       data = {
         ...data,

--- a/assets/javascripts/discourse/models/page.js.es6
+++ b/assets/javascripts/discourse/models/page.js.es6
@@ -5,12 +5,7 @@ import EmberObject, { observer } from '@ember/object';
 import { Array as EmberArray } from '@ember/array';
 import { getURLWithCDN } from "discourse-common/lib/get-url";
 
-const StaticPage = EmberObject.extend({
-
-  init: function() {
-    this._super(...arguments);
-  }
-});
+const StaticPage = EmberObject.extend();
 
 function getOpts() {
   const siteSettings = Discourse.__container__.lookup('site-settings:main');
@@ -35,20 +30,20 @@ var StaticPages = EmberObject.extend({
 StaticPage.reopenClass({
 
   findAll: function() {
-    var staticPages = StaticPages.create({ content: [], loading: true });
-    ajax('/procourse-static-pages/admin/pages.json').then(function(pages) {
-      if (pages){
+    return ajax('/procourse-static-pages/admin/pages.json').then(function(pages) {
+      const staticPages = Array();
+      if (pages) {
         pages.forEach((staticPage) => {
           var page = JSON.parse(staticPage.value);
+          const cooked = page.html ? '' : new PrettyText(getOpts()).cook(page.raw).string;
           staticPages.pushObject(StaticPage.create({
             ...page,
-            cooked: page.html ? '' : new Handlebars.SafeString(new PrettyText(getOpts()).cook(page.raw)).string
+            cooked: cooked
           }));
         });
       }
-      staticPages.set('loading', false);
+      return Array(staticPages);
     });
-    return staticPages;
   },
 
   save: function(object, enabledOnly=false) {

--- a/assets/javascripts/discourse/models/page.js.es6
+++ b/assets/javascripts/discourse/models/page.js.es6
@@ -1,7 +1,8 @@
 import { ajax } from 'discourse/lib/ajax';
 import { default as PrettyText, buildOptions } from 'pretty-text/pretty-text';
 import Group from 'discourse/models/group';
-import EmberObject from '@ember/object';
+import EmberObject, { observer } from '@ember/object';
+import { Array as EmberArray } from '@ember/array';
 import { getURLWithCDN } from "discourse-common/lib/get-url";
 
 const StaticPage = EmberObject.extend({
@@ -22,13 +23,13 @@ function getOpts() {
 }
 
 
-var StaticPages = Ember.ArrayProxy.extend({
-  selectedItemChanged: function() {
+var StaticPages = EmberObject.extend({
+  selectedItemChanged: observer('selectedItem', function() {
     var selected = this.get('selectedItem');
-    this.get('content').forEach((i) => {
-      return i.set('selected', selected === i);
+    Array(this.get('content')).forEach(i => {
+      i.set('selected', selected === i);
     });
-  }.observes('selectedItem')
+  })
 });
 
 StaticPage.reopenClass({


### PR DESCRIPTION
Removes use of Ember.Copyable and other updates required for Ember 5.5 and the latest Discourse changes which were preventing the Plugins page from loading, as well as the options for the plugin itself.