### PR TITLE
DEV: Update ace-editor usage

### DIFF
--- a/assets/javascripts/discourse/templates/admin/plugins-procourse-static-pages.hbs
+++ b/assets/javascripts/discourse/templates/admin/plugins-procourse-static-pages.hbs
@@ -61,7 +61,13 @@
         </div>
         <div>
           {{#if selectedItem.html}}
-            {{ace-editor content=selectedItem.html_content editorId="html|common" mode="html" autofocus="true"}}
+            <AceEditor
+              @content={{selectedItem.html_content}}
+              @onChange={{fn (mut selectedItem.html_content)}}
+              @editorId="html|common"
+              @mode="html"
+              @autofocus={{true}}
+            />
           {{else}}
             {{d-editor value=selectedItem.raw class="raw-bio"}}
           {{/if}}


### PR DESCRIPTION
AceEditor is now a glimmer component (see: https://github.com/discourse/discourse/pull/28492) and it follows the "data down, actions up" pattern.